### PR TITLE
First stab at ignoring dirty specs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,8 @@ fn default_filename(filename: Option<String>) -> Result<PathBuf, clap::error::Er
 fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Error> {
     // Extract the filename itself, as well as the directory from `path`.
     assert!(path.is_file());
-    let filename_without_path = path.file_name().unwrap().to_str().unwrap();
-    let directory = path.parent().unwrap().to_str().unwrap();
+    let filename_without_path = path.file_name().unwrap();
+    let directory = path.parent().unwrap();
 
     let output = std::process::Command::new("git")
         .arg("-C")
@@ -109,11 +109,9 @@ fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Erro
         .output()
         .expect("Failed to run `git status");
 
-    let git_status = String::from_utf8_lossy(&output.stdout);
-
-    // This implies that the spec we're targeting has no uncommitted changes,
-    // and so we're safe to proceed with rewrapping.
-    if !git_status.contains(&filename_without_path) {
+    // This means that the spec we're targeting does not have uncommitted
+    // changes, so we're safe to proceed with rewrapping.
+    if output.stdout.is_empty() {
         return Ok(());
     }
     Err(Args::command().error(

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,8 +118,8 @@ fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Erro
 
     let git_status = String::from_utf8_lossy(&output.stdout);
 
-    // This implies that the spec we're targeting as no uncommitted changes, and
-    // so we're safe to proceed with rewrapping.
+    // This implies that the spec we're targeting has no uncommitted changes,
+    // and so we're safe to proceed with rewrapping.
     if !git_status.contains(&filename_without_path) {
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,21 +100,14 @@ fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Erro
     let filename_without_path = path.file_name().unwrap().to_str().unwrap();
     let directory = path.parent().unwrap().to_str().unwrap();
 
-    let output = if cfg!(target_os = "windows") {
-        std::process::Command::new("cmd")
-            .args([
-                "/C",
-                &format!("cd {}; git status --porcelain", directory),
-            ])
-            .output()
-            .expect("Failed to run `git status`")
-    } else {
-        std::process::Command::new("sh")
-            .arg("-c")
-            .arg(format!("cd {}; git status --porcelain", directory).as_str())
-            .output()
-            .expect("Failed to run `git status`")
-    };
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .arg("status")
+        .arg("--porcelain")
+        .arg(filename_without_path)
+        .output()
+        .expect("Failed to run `git status");
 
     let git_status = String::from_utf8_lossy(&output.stdout);
 
@@ -125,8 +118,7 @@ fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Erro
     }
     Err(Args::command().error(
         clap::error::ErrorKind::ValueValidation,
-        "Spec must not have uncommitted changes to perform rewrapping. Please
-        commit your changes and try again.",
+        "Spec has uncommitted changes. Please commit your changes and try again.",
     ))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Erro
     // Extract the filename itself, as well as the directory from `path`.
     assert!(path.is_file());
     let filename_without_path = path.file_name().unwrap().to_str().unwrap();
-    let directory: &str = path.parent().unwrap().to_str().unwrap();
+    let directory = path.parent().unwrap().to_str().unwrap();
 
     let output = if cfg!(target_os = "windows") {
         std::process::Command::new("cmd")

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn default_filename(filename: Option<String>) -> Result<PathBuf, clap::error::Er
     ))
 }
 
-fn assert_no_uncommitted_changes(path: PathBuf) -> Result<(), clap::error::Error> {
+fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Error> {
     // Extract the filename itself, as well as the directory from `path`.
     assert!(path.is_file());
     let filename_without_path = path.file_name().unwrap().to_str().unwrap();
@@ -134,7 +134,7 @@ fn main() {
     let args = Args::parse();
     let filename = default_filename(args.filename).unwrap_or_else(|err| err.exit());
 
-    assert_no_uncommitted_changes(filename.clone()).unwrap_or_else(|err| err.exit());
+    assert_no_uncommitted_changes(&filename).unwrap_or_else(|err| err.exit());
 
     let (file, file_as_string): (File, String) = match read_file(&filename) {
         Ok((file, string)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,13 +94,11 @@ fn default_filename(filename: Option<String>) -> Result<PathBuf, clap::error::Er
     ))
 }
 
-fn assert_no_uncommitted_changes(mut path: PathBuf) -> Result<(), clap::error::Error> {
+fn assert_no_uncommitted_changes(path: PathBuf) -> Result<(), clap::error::Error> {
     // Extract the filename itself, as well as the directory from `path`.
     assert!(path.is_file());
-    let filename_without_path = String::from(path.file_name().unwrap().to_str().unwrap());
-    path.pop();
-    assert!(path.is_dir());
-    let directory = path.to_str().unwrap();
+    let filename_without_path = path.file_name().unwrap().to_str().unwrap();
+    let directory: &str = path.parent().unwrap().to_str().unwrap();
 
     let output = if cfg!(target_os = "windows") {
         std::process::Command::new("cmd")

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Erro
         std::process::Command::new("cmd")
             .args([
                 "/C",
-                format!("cd {}; git status --porcelain", directory).as_str(),
+                &format!("cd {}; git status --porcelain", directory),
             ])
             .output()
             .expect("Failed to run `git status`")


### PR DESCRIPTION
Per the last paragraph of https://github.com/domfarolino/specfmt/issues/3, I wanted to make the tool refuse to run on specs that have uncommitted changes, just in case the tool ever gets a bug where rewrapping gets screwed up and the author actually loses valuable spec changes that haven't been committed.

If this is too tedious to use and we're confident that there are no bugs of the sort mentioned above, maybe we can remove this, but in the early stages it seems safe to stick with.