### PR TITLE
Scope the rewrapper to changes in the current spec branch

### DIFF
--- a/source
+++ b/source
@@ -2,7 +2,7 @@
 
                            <p>This is a weird weird weird weird weird weird weird weird weird weird
                            weird weird weird weird weird weird weird weird weird weird weird weird
-                           weird weird weird weird weird weird weird weird weird weird weird weird
+                           weird weird weird weird weird weird weird weird weird weird weird weird this and the other stuff oh my goodness that's wild
                            weird weird weird weird weird weird weird weird weird weird weird weird
                            weird weird weird test</p>
 

--- a/source
+++ b/source
@@ -2,7 +2,7 @@
 
                            <p>This is a weird weird weird weird weird weird weird weird weird weird
                            weird weird weird weird weird weird weird weird weird weird weird weird
-                           weird weird weird weird weird weird weird weird weird weird weird weird this and the other stuff oh my goodness that's wild
+                           weird weird weird weird weird weird weird weird weird weird weird weird
                            weird weird weird weird weird weird weird weird weird weird weird weird
                            weird weird weird test</p>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,20 @@ fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
     lines
 }
 
+fn apply_diff(lines: &mut Vec<(bool, &str)>, diff: &Vec<&str>) {
+    let mut i = 1;
+    for tuple in lines {
+        if tuple.1.trim() == diff[i].trim() {
+            // println!("Setting diff = true!");
+            tuple.0 = true;
+            i = i + 1;
+        }
+        if i == diff.len() {
+            break;
+        }
+    }
+}
+
 fn main() {
     let args = Args::parse();
     let filename = default_filename(args.filename).unwrap_or_else(|err| err.exit());
@@ -230,10 +244,12 @@ fn main() {
     };
 
     let lines: Vec<&str> = file_as_string.split("\n").collect();
-    let lines: Vec<(bool, &str)> = lines.iter().map(|&line| (true, line)).collect();
+    let mut lines: Vec<(bool, &str)> = lines.iter().map(|&line| (false, line)).collect();
+
+    apply_diff(&mut lines, &diff);
 
     // Initiate unwrapping/rewrapping.
-    let rewrapped_lines = rewrapper::rewrap_lines(lines, diff, args.wrap);
+    let rewrapped_lines = rewrapper::rewrap_lines(lines, diff.len(), args.wrap);
 
     // Join all lines and write to file.
     let file_as_string = rewrapped_lines.join("\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,7 @@ mod test {
     use test_generator::test_resources;
 
     #[test_resources("testcases/*.in.html")]
-    fn rewrap_tests(input: &str) {
+    fn simple_rewrap_tests(input: &str) {
         assert!(Path::new(input).exists());
         let output = input.replace("in.html", "out.html");
         assert!(Path::new(&output).exists());

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,18 +197,6 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
         .output()
         .expect("Failed to compute `git diff`");
 
-    // TODO(domfarolino): See if there is a better way to do this.
-    let status = git_diff.status.code().unwrap();
-    if status != 0 {
-        return Err(Args::command().error(
-            clap::error::ErrorKind::ValueValidation,
-            format!(
-                "Failed to compute diff between branches '{}' and '{}'. Git exit code: {}",
-                current_branch, base_branch, status
-            ),
-        ));
-    }
-
     Ok(String::from_utf8(git_diff.stdout).unwrap())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,10 @@ fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
 }
 
 fn apply_diff(lines: &mut Vec<(bool, &str)>, diff: &Vec<&str>) {
+    if diff.len() == 0 {
+      return;
+    }
+
     let mut i = 1;
     for tuple in lines {
         if tuple.1.trim() == diff[i].trim() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,10 +292,8 @@ fn main() {
         Err(error) => panic!("Error opening file '{}': {:?}", filename.display(), error),
     };
 
-    let lines: Vec<&str> = file_as_string.split("\n").collect();
-    let mut lines: Vec<Line> = lines
-        .iter()
-        .map(|&line_contents| Line {
+    let mut lines: Vec<Line> = file_as_string.split("\n")
+        .map(|line_contents| Line {
             should_format: args.full_spec,
             contents: line_contents,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,14 +213,12 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
 }
 
 fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
-    let lines: Vec<&str> = diff
-        .split("\n")
+    diff.split("\n")
         // Only consider lines that start with "+" and more than one character.
         .filter(|line| line.starts_with("+") && line.len() > 1)
         // Remove the "+" version control prefix.
         .map(|e| &e[1..])
-        .collect();
-    lines
+        .collect()
 }
 
 // Marks all of the lines in `lines` as needing format if and only if they

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,8 @@ fn main() {
         Err(error) => panic!("Error opening file '{}': {:?}", filename.display(), error),
     };
 
-    let mut lines: Vec<Line> = file_as_string.split("\n")
+    let mut lines: Vec<Line> = file_as_string
+        .split("\n")
         .map(|line_contents| Line {
             // If we are to format the entire spec, then mark each line as
             // subject to formatting.
@@ -365,5 +366,4 @@ mod test {
         let file_as_string: String = wrapped_lines.join("\n");
         assert_eq!(file_as_string, out_string);
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,8 +230,11 @@ fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
 //   2.) The preexisting line in the spec appears after lines that exactly match
 //       all previous lines in the git diff.
 //
-// To see this problem in action, see the tests:
+// To see this problem in action, see the test:
 //   - testcases/git_diff/duplicate-lines.in.html
+//
+// The following test on the other hand, shows how we're unlikely to hit the
+// aforementioned bug though:
 //   - testcases/git_diff/duplicate-lines-separated.in.html
 //
 // This problem would go away entirely once we give all lines in `diff` a proper

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,11 +201,10 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
 
 fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
     let lines: Vec<&str>= diff.split("\n")
-        .enumerate()
         // Only consider lines that start with "+" and more than one character.
-        .filter(|&(idx, line)| line.starts_with("+") && line.len() > 1)
+        .filter(|line| line.starts_with("+") && line.len() > 1)
         // Remove the "+" version control prefix.
-        .map(|(_, e)| &e[1..])
+        .map(|e| &e[1..])
         .collect();
     lines
 }
@@ -220,7 +219,7 @@ fn main() {
 
     let diff = git_diff(&filename).unwrap_or_else(|err| err.exit());
     let diff = sanitized_diff_lines(&diff);
-    println!("{:#?}", diff);
+    // println!("{:#?}", diff);
 
     let (file, file_as_string): (File, String) = match read_file(&filename) {
         Ok((file, string)) => {
@@ -231,6 +230,7 @@ fn main() {
     };
 
     let lines: Vec<&str> = file_as_string.split("\n").collect();
+    let lines: Vec<(bool, &str)> = lines.iter().map(|&line| (true, line)).collect();
 
     // Initiate unwrapping/rewrapping.
     let rewrapped_lines = rewrapper::rewrap_lines(lines, diff, args.wrap);

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,17 +228,10 @@ fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
 //   1.) A line you add is identical to a previous, preexisting one in the spec
 //   2.) The preexisting line in the spec appears after lines that exactly match
 //       all previous lines in the git diff.
-// Consider the example:
-//  +----------+
-// 1| My spec  |
-// 2|          |
-// 3|+ Intro   |
-// 4|+ My spec |
-//  +----------+
-// It might sound like line 1 would get marked as a candidate for reformatting
-// given the flaws in this algorithm, since it matches line 4 in the computed
-// diff, but it wouldn't. Only a line matching "My spec" that comees *after*
-// a line "Intro" would get marked as a candidate for reformatting.
+//
+// To see this problem in action, see the tests:
+//   - testcases/git_diff/duplicate-lines.in.html
+//   - testcases/git_diff/duplicate-lines-separated.in.html
 //
 // This problem would go away entirely once we give all lines in `diff` a proper
 // line number.

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,10 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
     if status != 0 {
         return Err(Args::command().error(
             clap::error::ErrorKind::ValueValidation,
-            format!("Failed to compute diff between branches '{}' and '{}'. Git exit code: {}", current_branch, base_branch, status),
+            format!(
+                "Failed to compute diff between branches '{}' and '{}'. Git exit code: {}",
+                current_branch, base_branch, status
+            ),
         ));
     }
 
@@ -204,7 +207,8 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
 }
 
 fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
-    let lines: Vec<&str>= diff.split("\n")
+    let lines: Vec<&str> = diff
+        .split("\n")
         // Only consider lines that start with "+" and more than one character.
         .filter(|line| line.starts_with("+") && line.len() > 1)
         // Remove the "+" version control prefix.
@@ -240,21 +244,21 @@ fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
 // line number.
 fn apply_diff(lines: &mut Vec<(bool, &str)>, diff: &Vec<&str>) {
     if diff.len() == 0 {
-      return;
+        return;
     }
 
     let mut iter = diff.iter().peekable();
     // TODO(domfarolino): Remove this once we sanitize the `diff` better.
     iter.next(); // Skip the first bogus line.
     for line in lines {
-      if line.1 == **iter.peek().unwrap() {
-        line.0 = true;
-        iter.next();
-      }
+        if line.1 == **iter.peek().unwrap() {
+            line.0 = true;
+            iter.next();
+        }
 
-      if iter.peek() == None {
-        break;
-      }
+        if iter.peek() == None {
+            break;
+        }
     }
 }
 
@@ -263,7 +267,7 @@ fn main() {
     let filename = default_filename(args.filename).unwrap_or_else(|err| err.exit());
 
     if !args.ignore_uncommitted_changes {
-      assert_no_uncommitted_changes(&filename).unwrap_or_else(|err| err.exit());
+        assert_no_uncommitted_changes(&filename).unwrap_or_else(|err| err.exit());
     }
 
     let diff = if !args.full_spec {
@@ -319,10 +323,11 @@ mod test {
         let (_in_file, in_string) = read_file(Path::new(input)).unwrap();
         let (_out_file, out_string) = read_file(Path::new(&output)).unwrap();
 
-        let lines: Vec<&str> = in_string.split("\n").collect();
+        let lines: Vec<(bool, &str)> = in_string.split("\n").map(|line| (true, line)).collect();
+        let length = lines.len();
 
         // Initiate unwrapping/rewrapping.
-        let wrapped_lines = rewrapper::rewrap_lines(lines, 100);
+        let wrapped_lines = rewrapper::rewrap_lines(lines, length, 100);
         let file_as_string: String = wrapped_lines.join("\n");
         assert_eq!(file_as_string, out_string);
     }

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -2,6 +2,23 @@ use super::Line;
 use lazy_static::lazy_static;
 use regex::Regex;
 
+// A struct similar to `Line`, with the exception that `OwnedLine` does not
+// maintain a string reference, but rather an owned `String`. We cannot easily
+// keep a reference to the original spec strings, because due to unwrapping,
+// some of the lines of a spec have been mutated beyond the capability of
+// slicing.
+//
+// That is, when turn `LINE + NEW_LINE + LINE2` into `LINE + SPACE + LINE2`, we
+// are incapable of taking a slice over the entire line since it would include
+// two non-contiguous slices separated by a brand new space character. We could
+// modify `Line` to support this case where a given "line" consists of multiple
+// string slices and owned string spaces, for efficiency, but for now we just use
+// `OwnedLine` since it is easier.
+pub struct OwnedLine {
+    should_format: bool,
+    contents: String,
+}
+
 pub fn rewrap_lines(lines: Vec<Line>, diff_lines: usize, column_length: u8) -> Vec<String> {
     println!("- - The Great Rewrapper - -");
     println!(
@@ -10,7 +27,7 @@ pub fn rewrap_lines(lines: Vec<Line>, diff_lines: usize, column_length: u8) -> V
         diff_lines,
         column_length
     );
-    let unwrapped_lines: Vec<(bool, String)> = unwrap_lines(lines);
+    let unwrapped_lines: Vec<OwnedLine> = unwrap_lines(lines);
     wrap_lines(unwrapped_lines, column_length)
 }
 
@@ -39,16 +56,16 @@ fn exempt_from_wrapping(line: &str) -> bool {
 //
 // To see this failure in action, see the test:
 //   - testcases/git_diff/addition-in-middle-of-p.in.html
-fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
+fn unwrap_lines(lines: Vec<Line>) -> Vec<OwnedLine> {
     // TODO(domfarolino): We should be returning something like a `Vec<Line>`
     // here, but with owned strings (if necessary, as we currently have it)
     // instead of string slices. The tuple is a little opaque.
-    let mut return_lines = Vec::<(bool, String)>::new();
+    let mut return_lines = Vec::<OwnedLine>::new();
     let mut previous_line_smushable = false;
 
     for line in lines {
         if is_standalone_line(line.contents.trim()) {
-            return_lines.push((line.should_format, line.contents.to_string()));
+            return_lines.push(OwnedLine {should_format: line.should_format, contents: line.contents.to_string()});
             previous_line_smushable = false;
         } else {
             if previous_line_smushable == true && line.should_format {
@@ -57,12 +74,10 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
                 // If we're unwrapping this line by tacking it onto the end of
                 // the previous one, we have to mark the previous line as a
                 // candidate for formatting (it might not already be).
-                return_lines[n - 1].0 = true;
-                return_lines[n - 1]
-                    .1
-                    .push_str(&(String::from(" ") + line.contents.trim()));
+                return_lines[n - 1].should_format = true;
+                return_lines[n - 1].contents.push_str(&(String::from(" ") + line.contents.trim()));
             } else {
-                return_lines.push((line.should_format, line.contents.to_string()));
+                return_lines.push(OwnedLine {should_format: line.should_format, contents: line.contents.to_string()});
             }
 
             previous_line_smushable = !must_break(line.contents);
@@ -72,13 +87,13 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
     return_lines
 }
 
-fn wrap_lines(lines: Vec<(bool, String)>, column_length: u8) -> Vec<String> {
+fn wrap_lines(lines: Vec<OwnedLine>, column_length: u8) -> Vec<String> {
     let mut rewrapped_lines: Vec<String> = Vec::new();
-    for (should_format, line) in lines.iter() {
-        if line.len() <= column_length.into() || exempt_from_wrapping(line) || !should_format {
-            rewrapped_lines.push(line.to_string());
+    for line in lines.iter() {
+        if line.contents.len() <= column_length.into() || exempt_from_wrapping(&line.contents) || !line.should_format {
+            rewrapped_lines.push(line.contents.to_string());
         } else {
-            rewrapped_lines.append(&mut wrap_single_line(&line, column_length));
+            rewrapped_lines.append(&mut wrap_single_line(&line.contents, column_length));
         }
     }
 

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -42,7 +42,9 @@ fn unwrap_lines(lines: Vec<(bool, &str)>) -> Vec<(bool, String)> {
                 let n = return_lines.len();
                 // TODO(domfarolino): Document this.
                 return_lines[n - 1].0 = true;
-                return_lines[n - 1].1.push_str(&(" ".to_owned() + line.trim()));
+                return_lines[n - 1]
+                    .1
+                    .push_str(&(" ".to_owned() + line.trim()));
             } else {
                 return_lines.push((should_format, line.to_string()));
             }

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -29,6 +29,14 @@ fn exempt_from_wrapping(line: &str) -> bool {
     FULL_DT_TAG.is_match(line)
 }
 
+// TODO(domfarolino): BEFORE MERGING: There is a bug in this algorithm where if
+// a git diff makes the middle of a perfectly-formatted paragraph too long,
+// we'll only rewrap that line, which might leave subsequent lines sub-optimally
+// rewrapped (too short). If we push new text to a new line, then we should
+// unwrap that line and repeat the process for the rest of... I guess the
+// paragraph, not sure. This is really a function of the fact that we unwrap and
+// rewrap in two different phases I guess, but we should be able to work around
+// that here.
 fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
     // TODO(domfarolino): We should be returning something like a `Vec<Line>`
     // here, but with owned strings (if necessary, as we currently have it)

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -1,7 +1,8 @@
+use super::Line;
 use lazy_static::lazy_static;
 use regex::Regex;
 
-pub fn rewrap_lines(lines: Vec<(bool, &str)>, diff_lines: usize, column_length: u8) -> Vec<String> {
+pub fn rewrap_lines(lines: Vec<Line>, diff_lines: usize, column_length: u8) -> Vec<String> {
     println!("- - The Great Rewrapper - -");
     println!(
         "The spec has {} lines total. We'll try to wrap {} lines to {} characters",
@@ -28,28 +29,28 @@ fn exempt_from_wrapping(line: &str) -> bool {
     FULL_DT_TAG.is_match(line)
 }
 
-fn unwrap_lines(lines: Vec<(bool, &str)>) -> Vec<(bool, String)> {
+fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
     let mut return_lines = Vec::<(bool, String)>::new();
     let mut previous_line_smushable = false;
 
-    for (should_format, line) in lines {
-        if is_standalone_line(line.trim()) {
-            return_lines.push((should_format, line.to_string()));
+    for line in lines {
+        if is_standalone_line(line.contents.trim()) {
+            return_lines.push((line.should_format, line.contents.to_string()));
             previous_line_smushable = false;
         } else {
-            if previous_line_smushable == true && should_format {
+            if previous_line_smushable == true && line.should_format {
                 assert_ne!(return_lines.len(), 0);
                 let n = return_lines.len();
                 // TODO(domfarolino): Document this.
                 return_lines[n - 1].0 = true;
                 return_lines[n - 1]
                     .1
-                    .push_str(&(" ".to_owned() + line.trim()));
+                    .push_str(&(" ".to_owned() + line.contents.trim()));
             } else {
-                return_lines.push((should_format, line.to_string()));
+                return_lines.push((line.should_format, line.contents.to_string()));
             }
 
-            previous_line_smushable = !must_break(line);
+            previous_line_smushable = !must_break(line.contents);
         }
     }
 

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -1,7 +1,8 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 
-pub fn rewrap_lines(lines: Vec<&str>, diff: Vec<&str>, column_length: u8) -> Vec<String> {
+pub fn rewrap_lines(lines: Vec<(bool, &str)>, diff: Vec<&str>, column_length: u8) -> Vec<String> {
+    // let lines: Vec<&str> = lines.iter().map(|tuple| tuple.1).collect();
     println!("- - The Great Rewrapper - -");
     println!(
         "The spec has {} lines total. We'll try to wrap {} lines to {} characters",
@@ -28,16 +29,16 @@ fn exempt_from_wrapping(line: &str) -> bool {
     FULL_DT_TAG.is_match(line)
 }
 
-fn unwrap_lines(lines: Vec<&str>, diff: &Vec<&str>) -> Vec<String> {
+fn unwrap_lines(lines: Vec<(bool, &str)>) -> Vec<String> {
     let mut return_lines = Vec::<String>::new();
     let mut previous_line_smushable = false;
 
-    for line in lines {
+    for (should_unwrap, line) in lines {
         if is_standalone_line(line.trim()) {
             return_lines.push(line.to_string());
             previous_line_smushable = false;
         } else {
-            if previous_line_smushable == true && diff.contains(&line.trim()) {
+            if previous_line_smushable == true && should_unwrap {
                 assert_ne!(return_lines.len(), 0);
                 let n = return_lines.len();
                 return_lines[n - 1].push_str(&(" ".to_owned() + line.trim()));

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -29,14 +29,16 @@ fn exempt_from_wrapping(line: &str) -> bool {
     FULL_DT_TAG.is_match(line)
 }
 
-// TODO(domfarolino): BEFORE MERGING: There is a bug in this algorithm where if
-// a git diff makes the middle of a perfectly-formatted paragraph too long,
-// we'll only rewrap that line, which might leave subsequent lines sub-optimally
-// rewrapped (too short). If we push new text to a new line, then we should
-// unwrap that line and repeat the process for the rest of... I guess the
-// paragraph, not sure. This is really a function of the fact that we unwrap and
-// rewrap in two different phases I guess, but we should be able to work around
-// that here.
+// TODO: This algorithm has a bug where if `git diff` describes an addition to a
+// line in a perfectly-formatted paragraph, such that the addition makes the
+// line now too long middle of a perfectly-formatted paragraph, we'll only
+// rewrap that line, which might leave subsequent lines sub-optimally wrapped
+// (too short). If a diff pushes new text to an existing line, we should do
+// something like manually unwrap that line and repeat the process for the rest
+// of the paragraph or something.
+//
+// To see this failure in action, see the test:
+//   - testcases/git_diff/addition-in-middle-of-p.in.html
 fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
     // TODO(domfarolino): We should be returning something like a `Vec<Line>`
     // here, but with owned strings (if necessary, as we currently have it)

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -65,7 +65,10 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<OwnedLine> {
 
     for line in lines {
         if is_standalone_line(line.contents.trim()) {
-            return_lines.push(OwnedLine {should_format: line.should_format, contents: line.contents.to_string()});
+            return_lines.push(OwnedLine {
+                should_format: line.should_format,
+                contents: line.contents.to_string(),
+            });
             previous_line_smushable = false;
         } else {
             if previous_line_smushable == true && line.should_format {
@@ -75,9 +78,14 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<OwnedLine> {
                 // the previous one, we have to mark the previous line as a
                 // candidate for formatting (it might not already be).
                 return_lines[n - 1].should_format = true;
-                return_lines[n - 1].contents.push_str(&(String::from(" ") + line.contents.trim()));
+                return_lines[n - 1]
+                    .contents
+                    .push_str(&(String::from(" ") + line.contents.trim()));
             } else {
-                return_lines.push(OwnedLine {should_format: line.should_format, contents: line.contents.to_string()});
+                return_lines.push(OwnedLine {
+                    should_format: line.should_format,
+                    contents: line.contents.to_string(),
+                });
             }
 
             previous_line_smushable = !must_break(line.contents);
@@ -90,7 +98,10 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<OwnedLine> {
 fn wrap_lines(lines: Vec<OwnedLine>, column_length: u8) -> Vec<String> {
     let mut rewrapped_lines: Vec<String> = Vec::new();
     for line in lines.iter() {
-        if line.contents.len() <= column_length.into() || exempt_from_wrapping(&line.contents) || !line.should_format {
+        if line.contents.len() <= column_length.into()
+            || exempt_from_wrapping(&line.contents)
+            || !line.should_format
+        {
             rewrapped_lines.push(line.contents.to_string());
         } else {
             rewrapped_lines.append(&mut wrap_single_line(&line.contents, column_length));

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -30,6 +30,9 @@ fn exempt_from_wrapping(line: &str) -> bool {
 }
 
 fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
+    // TODO(domfarolino): We should be returning something like a `Vec<Line>`
+    // here, but with owned strings (if necessary, as we currently have it)
+    // instead of string slices. The tuple is a little opaque.
     let mut return_lines = Vec::<(bool, String)>::new();
     let mut previous_line_smushable = false;
 
@@ -41,11 +44,13 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<(bool, String)> {
             if previous_line_smushable == true && line.should_format {
                 assert_ne!(return_lines.len(), 0);
                 let n = return_lines.len();
-                // TODO(domfarolino): Document this.
+                // If we're unwrapping this line by tacking it onto the end of
+                // the previous one, we have to mark the previous line as a
+                // candidate for formatting (it might not already be).
                 return_lines[n - 1].0 = true;
                 return_lines[n - 1]
                     .1
-                    .push_str(&(" ".to_owned() + line.contents.trim()));
+                    .push_str(&(String::from(" ") + line.contents.trim()));
             } else {
                 return_lines.push((line.should_format, line.contents.to_string()));
             }

--- a/testcases/git_diff/addition-in-middle-of-p.diff
+++ b/testcases/git_diff/addition-in-middle-of-p.diff
@@ -1,0 +1,12 @@
+diff --git a/testcases/git_diff/addition-in-middle-of-p.in.html b/testcases/git_diff/addition-in-middle-of-p.in.html
+index e69351f..f550f33 100644
+--- a/testcases/git_diff/addition-in-middle-of-p.in.html
++++ b/testcases/git_diff/addition-in-middle-of-p.in.html
+@@ -1,6 +1,6 @@
+ 
+                           <p>This is my specification and it is intended for authors of documents
+-                          and scripts that use the features defined in this specification and so on
++                          and scripts that use the features defined in this specification and so on adding more text here that is too long
+                           and more things similar to the other things and workers and threads and
+                           documents woohoo that stuff is just so great let's write specs until we
+                           can't type anymore that's my ted talk.</p>

--- a/testcases/git_diff/addition-in-middle-of-p.in.html
+++ b/testcases/git_diff/addition-in-middle-of-p.in.html
@@ -1,3 +1,7 @@
+<!-- This test shows broken formatting behavior: we append "adding more text here that is too long"
+to an already-formatted line, and specfmt properly formats that line, but none after it even though
+the subsequent lines may need reformatting after we format the single line with the addition-->
+
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on adding more text here that is too long

--- a/testcases/git_diff/addition-in-middle-of-p.in.html
+++ b/testcases/git_diff/addition-in-middle-of-p.in.html
@@ -1,0 +1,6 @@
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification and so on adding more text here that is too long
+                          and more things similar to the other things and workers and threads and
+                          documents woohoo that stuff is just so great let's write specs until we
+                          can't type anymore that's my ted talk.</p>

--- a/testcases/git_diff/addition-in-middle-of-p.out.html
+++ b/testcases/git_diff/addition-in-middle-of-p.out.html
@@ -1,0 +1,7 @@
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification and so on
+                          adding more text here that is too long
+                          and more things similar to the other things and workers and threads and
+                          documents woohoo that stuff is just so great let's write specs until we
+                          can't type anymore that's my ted talk.</p>

--- a/testcases/git_diff/addition-in-middle-of-p.out.html
+++ b/testcases/git_diff/addition-in-middle-of-p.out.html
@@ -1,3 +1,7 @@
+<!-- This test shows broken formatting behavior: we append "adding more text here that is too long"
+to an already-formatted line, and specfmt properly formats that line, but none after it even though
+the subsequent lines may need reformatting after we format the single line with the addition-->
+
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on

--- a/testcases/git_diff/duplicate-lines-separated.diff
+++ b/testcases/git_diff/duplicate-lines-separated.diff
@@ -1,0 +1,11 @@
+diff --git a/testcases/git_diff/duplicate-lines-separated.in.html b/testcases/git_diff/duplicate-lines-separated.in.html
+index f4dccf2..a68a29d 100644
+--- a/testcases/git_diff/duplicate-lines-separated.in.html
++++ b/testcases/git_diff/duplicate-lines-separated.in.html
+@@ -1,2 +1,6 @@
+ 
+                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
++
++                          <h1>My specification</h1>
++
++                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines-separated.in.html
+++ b/testcases/git_diff/duplicate-lines-separated.in.html
@@ -1,0 +1,6 @@
+
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
+
+                          <h1>My specification</h1>
+
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines-separated.out.html
+++ b/testcases/git_diff/duplicate-lines-separated.out.html
@@ -1,0 +1,8 @@
+
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
+
+                          <h1>My specification</h1>
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification<span
+                          w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.diff
+++ b/testcases/git_diff/duplicate-lines.diff
@@ -1,0 +1,9 @@
+diff --git a/testcases/git_diff/duplicate-lines.in.html b/testcases/git_diff/duplicate-lines.in.html
+index f4dccf2..c4bf743 100644
+--- a/testcases/git_diff/duplicate-lines.in.html
++++ b/testcases/git_diff/duplicate-lines.in.html
+@@ -1,2 +1,4 @@
+ 
+                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
++
++                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.in.html
+++ b/testcases/git_diff/duplicate-lines.in.html
@@ -1,0 +1,4 @@
+
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
+
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.in.html
+++ b/testcases/git_diff/duplicate-lines.in.html
@@ -1,3 +1,6 @@
+<!-- This test highlights broken formatting behavior: the second line is the one that gets added in
+the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
+
 
                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
 

--- a/testcases/git_diff/duplicate-lines.out.html
+++ b/testcases/git_diff/duplicate-lines.out.html
@@ -1,0 +1,6 @@
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification<span
+                          w-nodev>, implementers ......</span>.</p>
+
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.out.html
+++ b/testcases/git_diff/duplicate-lines.out.html
@@ -1,3 +1,6 @@
+<!-- This test highlights broken formatting behavior: the second line is the one that gets added in
+the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
+
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification<span


### PR DESCRIPTION
This commit fixes https://github.com/domfarolino/specfmt/issues/3 by scoping the rewrapper to changes in the current branch of the target spec, as compared with the base branch (either `master` or `main`).

There are a couple improvements that could be made after this PR lands:
 - Instead of only considering the possible base branches `master` or `main`, we could look at the commit history and find the first branch in the history that is not the current branch, and use _that_ as the base branch. Alternatively we could accept a custom base branch as a command line argument
 - `apply_diff()` could be improved, as per the documentation above it. Currently we don't track the line numbers of the output in `git diff`, so it is possible for us to format a line in the spec that "matches" a line in the `git diff` output, but is in a different place (earlier, for example). Getting this right will require some more machinery to store which lines in the real spec each line in the diff corresponds to, but for the short-term, this PR will get us up and running to where the tool is actually useful. There are two tests that this PR adds to assert the current behavior
 - With this change, the rewrapper breaks in the case where the git diff only describes a change where text is added to the middle of a perfectly-formatted paragraph. Documentation above `unwrap_lines()` describes this, and there is a test that asserts this as well.