### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn default_filename(filename: Option<String>) -> Result<PathBuf, clap::error::Er
     ))
 }
 
-fn assert_no_uncommitted_changes(path: &PathBuf) -> Result<(), clap::error::Error> {
+fn assert_no_uncommitted_changes(path: &Path) -> Result<(), clap::error::Error> {
     // Extract the filename itself, as well as the directory from `path`.
     assert!(path.is_file());
     let filename_without_path = path.file_name().unwrap();
@@ -203,10 +203,10 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
     Ok(String::from_utf8(git_diff.stdout).unwrap())
 }
 
-// Takes the `String` output of `git_diff` above, and filters out irrelevant
+// Takes the `&str` output of `git_diff` above, and filters out irrelevant
 // lines. Cannot be a part of `git_diff` because this returns a vector of string
 // slices (for efficiency) on top of strings allocated inside of `git_diff`.
-fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
+fn sanitized_diff_lines(diff: &str) -> Vec<&str> {
     diff.split('\n')
         .enumerate()
         // Strip the first 5 version control lines, and only consider lines

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
 
     // Could not find a branch named `master` or `main`. This configuration is
     // considered invalid.
-    if base_branch == "" {
+    if base_branch.is_empty() {
         return Err(Args::command().error(
             clap::error::ErrorKind::ValueValidation,
             format!("Cannot find a 'master' or 'main' base branch with which to compare the current branch '{}'of the spec", current_branch),
@@ -207,11 +207,11 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
 // lines. Cannot be a part of `git_diff` because this returns a vector of string
 // slices (for efficiency) on top of strings allocated inside of `git_diff`.
 fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
-    diff.split("\n")
+    diff.split('\n')
         .enumerate()
         // Strip the first 5 version control lines, and only consider lines
         // prefixed with "+" that are more than one character long.
-        .filter(|&(i, line)| i > 4 && line.starts_with("+") && line.len() > 1)
+        .filter(|&(i, line)| i > 4 && line.starts_with('+') && line.len() > 1)
         // Remove the "+" version control prefix.
         .map(|(_, line)| &line[1..])
         .collect()
@@ -222,7 +222,7 @@ fn sanitized_diff_lines(diff: &String) -> Vec<&str> {
 // the *contents* of the lines in `diff` with `lines`, not the actual line
 // numbers. See https://github.com/domfarolino/specfmt/issues/7.
 fn apply_diff(lines: &mut Vec<Line>, diff: &Vec<&str>) {
-    if diff.len() == 0 {
+    if diff.is_empty() {
         return;
     }
 
@@ -233,7 +233,7 @@ fn apply_diff(lines: &mut Vec<Line>, diff: &Vec<&str>) {
             iter.next();
         }
 
-        if iter.peek() == None {
+        if iter.peek().is_none() {
             break;
         }
     }
@@ -263,7 +263,7 @@ fn main() {
     };
 
     let mut lines: Vec<Line> = file_as_string
-        .split("\n")
+        .split('\n')
         .map(|line_contents| Line {
             // If we are to format the entire spec, then mark each line as
             // subject to formatting.
@@ -306,7 +306,7 @@ mod test {
         let (_out_file, out_string) = read_file(Path::new(&output)).unwrap();
 
         let lines: Vec<Line> = in_string
-            .split("\n")
+            .split('\n')
             .map(|line| Line {
                 should_format: true,
                 contents: line,
@@ -333,7 +333,7 @@ mod test {
         let (_diff_file, diff_string) = read_file(Path::new(&diff)).unwrap();
 
         let mut lines: Vec<Line> = in_string
-            .split("\n")
+            .split('\n')
             .map(|line| Line {
                 // Exempt all lines from formatting. `apply_diff()` below will
                 // reverse this for lines included in the diff.

--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -74,15 +74,15 @@ fn exempt_blocks(lines: &mut Vec<Line>) {
     let mut in_exempt_block: &str = "";
     for line in lines {
         // Only assign `in_exempt_block` if we're *not* already in one.
-        if in_exempt_block.len() == 0 {
-            in_exempt_block = open_exempt_tag(&line.contents);
+        if in_exempt_block.is_empty() {
+            in_exempt_block = open_exempt_tag(line.contents);
         }
 
         // If we're in an exempt block, mark the line as exempt from formatting,
         // and see if we've reached the close block.
-        if in_exempt_block.len() > 0 {
+        if !in_exempt_block.is_empty() {
             line.should_format = false;
-            if contains_close_tag(in_exempt_block, &line.contents) {
+            if contains_close_tag(in_exempt_block, line.contents) {
                 in_exempt_block = "";
             }
         }
@@ -96,7 +96,7 @@ lazy_static! {
     static ref HEADER_TAG: Regex = Regex::new(r#"<h[0-6].*>.*</h[0-6]>$"#).unwrap();
 }
 fn is_standalone_line(line: &str) -> bool {
-    line.len() == 0
+    line.is_empty()
         || SINGLE_TAG.is_match(line)
         || FULL_DT_TAG.is_match(line)
         || HEADER_TAG.is_match(line)
@@ -136,7 +136,7 @@ fn unwrap_lines(lines: Vec<Line>) -> Vec<OwnedLine> {
             });
             previous_line_smushable = false;
         } else {
-            if previous_line_smushable == true && line.should_format {
+            if previous_line_smushable && line.should_format {
                 assert_ne!(return_lines.len(), 0);
                 let n = return_lines.len();
                 // If we're unwrapping this line by tacking it onto the end of
@@ -186,7 +186,7 @@ fn wrap_single_line(line: &str, column_length: u8) -> Vec<String> {
     let indent: &str = &indent[1];
     let line = line.trim_start();
 
-    let mut words = line.split(" ");
+    let mut words = line.split(' ');
     // This will never panic; even if `line` is empty after we trim it, the
     // split collection will contain a single empty string. See
     // https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1035caa5a7a4324272c8966d36d323b4.


### PR DESCRIPTION
I found there are some warnings with `cargo clippy` so I just tried to use the `--fix` to fix most of the warnings and also manually fix the [`ptr_arg`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg) warning in the 2nd commit.