### PR TITLE
Fix additions in middle of formatted diffs

### DIFF
--- a/src/rewrapper.rs
+++ b/src/rewrapper.rs
@@ -120,9 +120,8 @@ fn exempt_from_wrapping(line: &str) -> bool {
     FULL_DT_TAG.is_match(line)
 }
 
-// Checking for if 'get diff' describes an addtion to 
-// already formatted lines, reformatting until we reach
-// the next empty newline
+// Checking for if 'git diff' describes an addtion to already formatted lines,
+// reformatting until we reachthe next empty newline
 fn mark_diff_lines_for_formatting(lines: &mut Vec<Line>) {
     let mut should_format = false;
 

--- a/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.diff
+++ b/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.diff
@@ -1,0 +1,11 @@
+diff --git a/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.in.html b/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.in.html
+index 514651e..cc7d3e4 100644
+--- a/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.in.html
++++ b/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.in.html
+@@ -1,5 +1,5 @@
+                           <p>This is my specification and it's intended for authors of documents and
+-                          scripts and this is the line that the developer will add some text to and
++                          scripts and this is the line that the developer will add some text to !!RIGHT HERE!! and
+                           this one isn't touched but has a fmt terminating condition (end para).</p>
+                           <p>This is my other paragraph
+                           and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.in.html
+++ b/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.in.html
@@ -1,0 +1,11 @@
+                          <p>This is my specification and it's intended for authors of documents and
+                          scripts and this is the line that the developer will add some text to !!RIGHT HERE!! and
+                          this one isn't touched but has a fmt terminating condition (end para).</p>
+                          <p>This is my other paragraph
+                          and it is also great</p>
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts and this line was not touched by the original diff, but has the format terminating
+                          condition (end paragraph). Therefore it should be formatted, but the formatting should go no further</p>
+                          <p>This is my other paragraph
+                          and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.out.html
+++ b/testcases/git_diff/addition-in-middle-but-last-line-has-terminating-condition.out.html
@@ -1,0 +1,12 @@
+                          <p>This is my specification and it's intended for authors of documents and
+                          scripts and this is the line that the developer will add some text to
+                          !!RIGHT HERE!! and this one isn't touched but has a fmt terminating
+                          condition (end para).</p>
+                          <p>This is my other paragraph
+                          and it is also great</p>
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts and this line was not touched by the original diff, but has the format terminating
+                          condition (end paragraph). Therefore it should be formatted, but the formatting should go no further</p>
+                          <p>This is my other paragraph
+                          and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-generic.diff
+++ b/testcases/git_diff/addition-in-middle-generic.diff
@@ -1,0 +1,13 @@
+diff --git a/testcases/git_diff/addition-in-middle-generic.in.html b/testcases/git_diff/addition-in-middle-generic.in.html
+index fe49a67..546ff71 100644
+--- a/testcases/git_diff/addition-in-middle-generic.in.html
++++ b/testcases/git_diff/addition-in-middle-generic.in.html
+@@ -4,7 +4,7 @@
+ 
+ 
+                           <p>This is my specification and it is intended for authors of documents
+-                          and scripts that use the features defined in this specification and so on
++                          and scripts that use the features defined in this specification and so on adding more text here that is too long
+                           and more things similar <li> to the other things and workers and threads and
+                           documents woohoo that stuff is just so great let's write specs until we
+                           can't type anymore </li> that's my ted talk.</p>

--- a/testcases/git_diff/addition-in-middle-generic.in.html
+++ b/testcases/git_diff/addition-in-middle-generic.in.html
@@ -1,0 +1,12 @@
+<!-- This test demonstrates new behavior, we will format the line and keep formatting until we
+hit a empty newline this means the line "This is seperated by a newline so even though this line 
+is long and should be formatted it will not be" will not be formatted has its irrelevent to the diff-->
+
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification and so on
+                          and more things similar <li> to the other things and workers and threads and
+                          documents woohoo that stuff is just so great let's write specs until we
+                          can't type anymore </li> that's my ted talk.</p>
+
+                          <p> This is seperated by a newline so even though this line is long and should be formatted it will not be </p>

--- a/testcases/git_diff/addition-in-middle-generic.in.html
+++ b/testcases/git_diff/addition-in-middle-generic.in.html
@@ -4,7 +4,7 @@ is long and should be formatted it will not be" will not be formatted has its ir
 
 
                           <p>This is my specification and it is intended for authors of documents
-                          and scripts that use the features defined in this specification and so on
+                          and scripts that use the features defined in this specification and so on adding more text here that is too long
                           and more things similar <li> to the other things and workers and threads and
                           documents woohoo that stuff is just so great let's write specs until we
                           can't type anymore </li> that's my ted talk.</p>

--- a/testcases/git_diff/addition-in-middle-generic.out.html
+++ b/testcases/git_diff/addition-in-middle-generic.out.html
@@ -4,10 +4,10 @@ is long and should be formatted it will not be" will not be formatted has its ir
 
 
                           <p>This is my specification and it is intended for authors of documents
-                          and scripts that use the features defined in this specification and so on 
+                          and scripts that use the features defined in this specification and so on
                           adding more text here that is too long and more things similar <li> to the
-                          other things and workers and threads and documents woohoo that stuff is 
-                          just so great let's write specs until we can't type anymore </li> that's my
-                          ted talk.</p>
+                          other things and workers and threads and documents woohoo that stuff is
+                          just so great let's write specs until we can't type anymore </li> that's
+                          my ted talk.</p>
 
                           <p> This is seperated by a newline so even though this line is long and should be formatted it will not be </p>

--- a/testcases/git_diff/addition-in-middle-generic.out.html
+++ b/testcases/git_diff/addition-in-middle-generic.out.html
@@ -1,0 +1,13 @@
+<!-- This test demonstrates new behavior, we will format the line and keep formatting until we
+hit a empty newline this means the line "This is seperated by a newline so even though this line 
+is long and should be formatted it will not be" will not be formatted has its irrelevent to the diff-->
+
+
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification and so on 
+                          adding more text here that is too long and more things similar <li> to the
+                          other things and workers and threads and documents woohoo that stuff is 
+                          just so great let's write specs until we can't type anymore </li> that's my
+                          ted talk.</p>
+
+                          <p> This is seperated by a newline so even though this line is long and should be formatted it will not be </p>

--- a/testcases/git_diff/addition-in-middle-no-newline.diff
+++ b/testcases/git_diff/addition-in-middle-no-newline.diff
@@ -1,0 +1,10 @@
+diff --git a/testcases/git_diff/addition-in-middle-no-newline.in.html b/testcases/git_diff/addition-in-middle-no-newline.in.html
+index ba3ee4b..7e15795 100644
+--- a/testcases/git_diff/addition-in-middle-no-newline.in.html
++++ b/testcases/git_diff/addition-in-middle-no-newline.in.html
+@@ -1,4 +1,4 @@
+                           <p>This is my specification and it is intended for authors of documents
+-                          and scripts that use the features defined in this specification and so adding new words here so lets see
++                          and scripts that use the features defined in this specification and </p> so adding new words here so lets see
+                           <p>This is my other paragraph
+                           and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-no-newline.diff
+++ b/testcases/git_diff/addition-in-middle-no-newline.diff
@@ -4,7 +4,8 @@ index ba3ee4b..7e15795 100644
 +++ b/testcases/git_diff/addition-in-middle-no-newline.in.html
 @@ -1,4 +1,4 @@
                            <p>This is my specification and it is intended for authors of documents
--                          and scripts that use the features defined in this specification and so adding new words here so lets see
-+                          and scripts that use the features defined in this specification and </p> so adding new words here so lets see
+
+-                          and scripts that use the features defined in this specification.</p>
++                          and scripts that use the features defined in this specification AND SO ADDING THESE NEW WORDS HERE LETS GO.</p>
                            <p>This is my other paragraph
                            and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-no-newline.in.html
+++ b/testcases/git_diff/addition-in-middle-no-newline.in.html
@@ -1,0 +1,4 @@
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification and </p> so adding new words here so lets see
+                          <p>This is my other paragraph
+                          and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-no-newline.in.html
+++ b/testcases/git_diff/addition-in-middle-no-newline.in.html
@@ -1,4 +1,4 @@
                           <p>This is my specification and it is intended for authors of documents
-                          and scripts that use the features defined in this specification and </p> so adding new words here so lets see
+                          and scripts that use the features defined in this specification AND SO ADDING THESE NEW WORDS HERE LETS GO.</p>
                           <p>This is my other paragraph
                           and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-no-newline.out.html
+++ b/testcases/git_diff/addition-in-middle-no-newline.out.html
@@ -1,0 +1,4 @@
+                          <p>This is my specification and it is intended for authors of documents
+                          and scripts that use the features defined in this specification and </p>
+                          so adding new words here so lets see <p>This is my other paragraph and it
+                          is also great</p>

--- a/testcases/git_diff/addition-in-middle-no-newline.out.html
+++ b/testcases/git_diff/addition-in-middle-no-newline.out.html
@@ -1,4 +1,5 @@
                           <p>This is my specification and it is intended for authors of documents
-                          and scripts that use the features defined in this specification and </p>
-                          so adding new words here so lets see <p>This is my other paragraph and it
-                          is also great</p>
+                          and scripts that use the features defined in this specification AND SO
+                          ADDING THESE NEW WORDS HERE LETS GO.</p>
+                          <p>This is my other paragraph
+                          and it is also great</p>

--- a/testcases/git_diff/addition-in-middle-of-p.out.html
+++ b/testcases/git_diff/addition-in-middle-of-p.out.html
@@ -5,7 +5,7 @@ the subsequent lines may need reformatting after we format the single line with 
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on
-                          adding more text here that is too long
-                          and more things similar to the other things and workers and threads and
-                          documents woohoo that stuff is just so great let's write specs until we
-                          can't type anymore that's my ted talk.</p>
+                          adding more text here that is too long and more things similar to the
+                          other things and workers and threads and documents woohoo that stuff is
+                          just so great let's write specs until we can't type anymore that's my ted
+                          talk.</p>


### PR DESCRIPTION
Fix issue where if a git diff adds an addition
to an already perfactly formated paragraph the
changes would only wrap the addition leaving to
suboptimal wrapping. #8 