### PR TITLE
Add diff scoping precision

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -206,8 +206,8 @@ fn git_diff(path: &Path) -> Result<String, clap::error::Error> {
 
 // Takes the `&str` output of `git_diff` above, and filters out irrelevant
 // lines. Cannot be a part of `git_diff` because this returns a vector of string
-// slices (for efficiency) and their line location on top of strings
-// allocated inside of `git_diff`.
+// slices (for efficiency) and their line location on top of strings allocated
+// inside of `git_diff`.
 fn sanitized_diff_lines(diff: &str) -> Vec<(usize, &str)> {
     let mut line_number = 0;
     let hunk_header_regex = Regex::new(r"@@ -(\d+),(\d+) \+(\d+),(\d+) @@").unwrap();
@@ -215,10 +215,10 @@ fn sanitized_diff_lines(diff: &str) -> Vec<(usize, &str)> {
     diff.split('\n')
         .enumerate()
         .filter_map(|(i, line)| {
-             // Extract line number from hunk header
+            // Extract line number from hunk header
             if let Some(captures) = hunk_header_regex.captures(line) {
-                // Start line number count at position 3 of hunk header
-                // which will indicate where in file we start counting lines
+            // Start line number count at position 3 of hunk header
+            // which will indicate where in file we start counting lines
                 line_number = captures[3].parse::<usize>().unwrap(); 
             }
             // Excludes version control lines
@@ -238,12 +238,13 @@ fn sanitized_diff_lines(diff: &str) -> Vec<(usize, &str)> {
             }
         })
         .collect()
-} 
+}
 
 fn apply_diff(lines: &mut Vec<Line>, diff: &Vec<(usize, &str)>) {
     if diff.is_empty() {
         return;
     }
+
     let mut current_line = 1;
     let mut iter = diff.iter().peekable();
     for line in lines {

--- a/testcases/git_diff/addition-in-middle-of-p.diff
+++ b/testcases/git_diff/addition-in-middle-of-p.diff
@@ -1,8 +1,9 @@
 diff --git a/testcases/git_diff/addition-in-middle-of-p.in.html b/testcases/git_diff/addition-in-middle-of-p.in.html
-index e69351f..f550f33 100644
+index 74f5142..18c8c7f 100644
 --- a/testcases/git_diff/addition-in-middle-of-p.in.html
 +++ b/testcases/git_diff/addition-in-middle-of-p.in.html
-@@ -1,6 +1,6 @@
+@@ -3,7 +3,7 @@ to an already-formatted line, and specfmt properly formats that line, but none a
+ the subsequent lines may need reformatting after we format the single line with the addition-->
  
                            <p>This is my specification and it is intended for authors of documents
 -                          and scripts that use the features defined in this specification and so on

--- a/testcases/git_diff/addition-in-middle-of-p.in.html
+++ b/testcases/git_diff/addition-in-middle-of-p.in.html
@@ -1,7 +1,3 @@
-<!-- This test shows broken formatting behavior: we append "adding more text here that is too long"
-to an already-formatted line, and specfmt properly formats that line, but none after it even though
-the subsequent lines may need reformatting after we format the single line with the addition-->
-
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on adding more text here that is too long

--- a/testcases/git_diff/addition-in-middle-of-p.in.html
+++ b/testcases/git_diff/addition-in-middle-of-p.in.html
@@ -1,3 +1,6 @@
+<!-- This test shows broken formatting behavior: we append "adding more text here that is too long"
+to an already-formatted line, and specfmt properly formats that line, but none after it even though
+the subsequent lines may need reformatting after we format the single line with the addition-->
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on adding more text here that is too long

--- a/testcases/git_diff/addition-in-middle-of-p.out.html
+++ b/testcases/git_diff/addition-in-middle-of-p.out.html
@@ -1,7 +1,3 @@
-<!-- This test shows broken formatting behavior: we append "adding more text here that is too long"
-to an already-formatted line, and specfmt properly formats that line, but none after it even though
-the subsequent lines may need reformatting after we format the single line with the addition-->
-
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on

--- a/testcases/git_diff/addition-in-middle-of-p.out.html
+++ b/testcases/git_diff/addition-in-middle-of-p.out.html
@@ -1,3 +1,6 @@
+<!-- This test shows broken formatting behavior: we append "adding more text here that is too long"
+to an already-formatted line, and specfmt properly formats that line, but none after it even though
+the subsequent lines may need reformatting after we format the single line with the addition-->
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification and so on

--- a/testcases/git_diff/duplicate-lines-diff-in-middle.diff
+++ b/testcases/git_diff/duplicate-lines-diff-in-middle.diff
@@ -1,0 +1,10 @@
+diff --git a/testcases/git_diff/duplicate-lines-diff-in-middle.in.html b/testcases/git_diff/duplicate-lines-diff-in-middle.in.html
+index 84c5a0a..e202f87 100644
+--- a/testcases/git_diff/duplicate-lines-diff-in-middle.in.html
++++ b/testcases/git_diff/duplicate-lines-diff-in-middle.in.html
+@@ -5,3 +5,5 @@
+                               the diff occurs at</p>
+ 
+                               <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
++
++                              <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines-diff-in-middle.in.html
+++ b/testcases/git_diff/duplicate-lines-diff-in-middle.in.html
@@ -1,0 +1,7 @@
+
+                              <p>This will not be formatted, want to test where a duplicate line occurs 
+                              but is deeper into the diff, this will properly test out the feature of 
+                              using the hunk header regex in order to determine which line number in the file
+                              the diff occurs at</p>
+
+                              <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines-diff-in-middle.out.html
+++ b/testcases/git_diff/duplicate-lines-diff-in-middle.out.html
@@ -6,4 +6,6 @@
 
                               <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
 
-                              <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
+                              <p>This is my specification and it is intended for authors of
+                              documents and scripts that use the features defined in this
+                              specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.diff
+++ b/testcases/git_diff/duplicate-lines.diff
@@ -1,9 +1,9 @@
 diff --git a/testcases/git_diff/duplicate-lines.in.html b/testcases/git_diff/duplicate-lines.in.html
-index f4dccf2..c4bf743 100644
+index db7318c..388f090 100644
 --- a/testcases/git_diff/duplicate-lines.in.html
 +++ b/testcases/git_diff/duplicate-lines.in.html
-@@ -1,2 +1,4 @@
- 
+@@ -2,3 +2,4 @@
+ the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
                            <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
-+
+ 
 +                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.in.html
+++ b/testcases/git_diff/duplicate-lines.in.html
@@ -1,4 +1,5 @@
-
+<!-- This test highlights broken formatting behavior: the second line is the one that gets added in
+the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
 
                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>

--- a/testcases/git_diff/duplicate-lines.in.html
+++ b/testcases/git_diff/duplicate-lines.in.html
@@ -1,6 +1,3 @@
-<!-- This test highlights broken formatting behavior: the second line is the one that gets added in
-the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
-
 
                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
 

--- a/testcases/git_diff/duplicate-lines.out.html
+++ b/testcases/git_diff/duplicate-lines.out.html
@@ -1,4 +1,5 @@
-
+<!-- This test highlights broken formatting behavior: the second line is the one that gets added in
+the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
                           <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
 
                           <p>This is my specification and it is intended for authors of documents

--- a/testcases/git_diff/duplicate-lines.out.html
+++ b/testcases/git_diff/duplicate-lines.out.html
@@ -1,9 +1,6 @@
-<!-- This test highlights broken formatting behavior: the second line is the one that gets added in
-the git diff, but the first line gets formatted. See documentation above `apply_diff` function-->
 
+                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>
 
                           <p>This is my specification and it is intended for authors of documents
                           and scripts that use the features defined in this specification<span
                           w-nodev>, implementers ......</span>.</p>
-
-                          <p>This is my specification and it is intended for authors of documents and scripts that use the features defined in this specification<span w-nodev>, implementers ......</span>.</p>


### PR DESCRIPTION
sanatize_diff_lines function will now return
both the line number and the string of each diff
this will cover the cases where a duplicate line
is added later into the file. #7