### PR TITLE
Generate `-absolute.html` files for debugging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,27 @@ mod test {
         // Initiate unwrapping/rewrapping.
         let wrapped_lines = rewrapper::rewrap_lines(lines, length, 100);
         let file_as_string: String = wrapped_lines.join("\n");
+
+        let actual = input.replace("in.html", "actual.html");
+        let actual_file  = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(Path::new(&actual))
+            .unwrap();
+
+        if file_as_string != out_string {
+            // Only write the `-actual.html` file if there is a failure.
+            match write_file(actual_file, file_as_string.clone()) {
+                Ok(_) => println!("Write succeeded"),
+                Err(error) => panic!("Error writing `-actual.html` file: {:?}", error),
+            }
+        } else {
+            // And remove any existing `-actual.html` files for passing tests.
+            if Path::new(&actual).exists() {
+                std::fs::remove_file(Path::new(&actual)).unwrap();
+            }
+        }
+
         assert_eq!(file_as_string, out_string);
     }
 
@@ -349,6 +370,27 @@ mod test {
         // Initiate unwrapping/rewrapping.
         let wrapped_lines = rewrapper::rewrap_lines(lines, length, 100);
         let file_as_string: String = wrapped_lines.join("\n");
+
+        let actual = input.replace("in.html", "actual.html");
+        let actual_file  = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(Path::new(&actual))
+            .unwrap();
+
+        if file_as_string != out_string {
+            // Only write the `-actual.html` file if there is a failure.
+            match write_file(actual_file, file_as_string.clone()) {
+                Ok(_) => println!("Write succeeded"),
+                Err(error) => panic!("Error writing `-actual.html` file: {:?}", error),
+            }
+        } else {
+            // And remove any existing `-actual.html` files for passing tests.
+            if Path::new(&actual).exists() {
+                std::fs::remove_file(Path::new(&actual)).unwrap();
+            }
+        }
+
         assert_eq!(file_as_string, out_string);
     }
 }


### PR DESCRIPTION
During `cargo test`, when the output of `specfmt` does not match the expected `-out.html` output, this PR makes the test runner generate an `-actual.html` file so you can see how the actual output differs from the expected output, instead of seeing super messy line-joined output in the terminal. Once a test is passing again, the test harness automatically deletes the generated `-actual.html` file, to clean up after itself.